### PR TITLE
remove raw filter to avoid html injection with hidden input

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -3,6 +3,6 @@
         <div class="quill" data-theme="{{ theme }}" data-id="{{ id }}" style="height: {{ height }}">
             {{ value|raw }}
         </div>
-        <input type="hidden" {{ block('widget_attributes') }} value="{{ value|raw }}" />
+        <input type="hidden" {{ block('widget_attributes') }} value="{{ value }}" />
     {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
The twig raw filter is a source of a bug in this case : If you write content in the quill editor, you save the content and then you come back on the form to update the content. Then the html string won't be escaped in the value attribute of the hidden input. So it will inject the quill editor content into the page instead of keeping it as the input value.